### PR TITLE
Link balance updates to transactions

### DIFF
--- a/app/api/transactions/[transaction_id]/route.ts
+++ b/app/api/transactions/[transaction_id]/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
 import type { PostRequestBody, TransactionData } from '../types'
+import { transactionHelper } from '@/utils/transaction-helper'
 
 export async function GET(
   _request: NextRequest,
@@ -40,6 +41,19 @@ export async function PATCH(
   try {
     const { transaction_id } = await params
     const { amount, transaction_type }: PostRequestBody = await request.json()
+    const { data: old, error: oldError } = await supabase
+      .from('transactions')
+      .select('amount, transaction_type')
+      .eq('transaction_id', transaction_id)
+      .single()
+
+    if (oldError) {
+      console.error(oldError)
+      return NextResponse.json(
+        { error: 'Transação não encontrada' },
+        { status: 404 },
+      )
+    }
 
     const updates = { amount, transaction_type }
 
@@ -53,6 +67,44 @@ export async function PATCH(
     if (error) {
       console.error(error)
       return NextResponse.json({ error: 'Erro ao atualizar' }, { status: 500 })
+    }
+
+    const { data: user, error: userError } = await supabase
+      .from('user')
+      .select('id, balance')
+      .limit(1)
+      .single()
+
+    if (userError) {
+      console.error(userError)
+      return NextResponse.json(
+        { error: 'Erro ao atualizar saldo' },
+        { status: 500 },
+      )
+    }
+
+    const oldAmount = transactionHelper.parseAmount(old.amount)
+    const newAmount = transactionHelper.parseAmount(amount)
+    const oldSigned = transactionHelper.isOutgoing(old.transaction_type)
+      ? -oldAmount
+      : oldAmount
+    const newSigned = transactionHelper.isOutgoing(transaction_type)
+      ? -newAmount
+      : newAmount
+    const balanceNumber = transactionHelper.parseAmount(user.balance)
+    const newBalance = balanceNumber + newSigned - oldSigned
+
+    const { error: balanceError } = await supabase
+      .from('user')
+      .update({ balance: transactionHelper.formatAmount(newBalance) })
+      .eq('id', user.id)
+
+    if (balanceError) {
+      console.error(balanceError)
+      return NextResponse.json(
+        { error: 'Erro ao atualizar saldo' },
+        { status: 500 },
+      )
     }
 
     return NextResponse.json({ success: true, transaction: data })
@@ -71,6 +123,19 @@ export async function DELETE(
 ) {
   try {
     const { transaction_id } = await params
+    const { data: old, error: oldError } = await supabase
+      .from('transactions')
+      .select('amount, transaction_type')
+      .eq('transaction_id', transaction_id)
+      .single()
+
+    if (oldError) {
+      console.error(oldError)
+      return NextResponse.json(
+        { error: 'Transação não encontrada' },
+        { status: 404 },
+      )
+    }
 
     const { error } = await supabase
       .from('transactions')
@@ -80,6 +145,40 @@ export async function DELETE(
     if (error) {
       console.error(error)
       return NextResponse.json({ error: 'Erro ao deletar' }, { status: 500 })
+    }
+
+    const { data: user, error: userError } = await supabase
+      .from('user')
+      .select('id, balance')
+      .limit(1)
+      .single()
+
+    if (userError) {
+      console.error(userError)
+      return NextResponse.json(
+        { error: 'Erro ao atualizar saldo' },
+        { status: 500 },
+      )
+    }
+
+    const oldAmount = transactionHelper.parseAmount(old.amount)
+    const signed = transactionHelper.isOutgoing(old.transaction_type)
+      ? -oldAmount
+      : oldAmount
+    const balanceNumber = transactionHelper.parseAmount(user.balance)
+    const newBalance = balanceNumber - signed
+
+    const { error: balanceError } = await supabase
+      .from('user')
+      .update({ balance: transactionHelper.formatAmount(newBalance) })
+      .eq('id', user.id)
+
+    if (balanceError) {
+      console.error(balanceError)
+      return NextResponse.json(
+        { error: 'Erro ao atualizar saldo' },
+        { status: 500 },
+      )
     }
 
     return NextResponse.json({ success: true })

--- a/app/api/transactions/types.ts
+++ b/app/api/transactions/types.ts
@@ -1,7 +1,7 @@
 export interface TransactionData {
   transaction_id: string
   amount: string
-  transaction_type: 'PIX' | 'Aplicação' | 'Câmbio'
+  transaction_type: 'PIX' | 'Aplicação' | 'Câmbio' | 'Depósito'
   date: string
 }
 

--- a/app/new-transaction/NewTransaction.tsx
+++ b/app/new-transaction/NewTransaction.tsx
@@ -143,6 +143,7 @@ export const NewTransaction = ({ transaction_id }: NewTransactionProps) => {
           <option value="PIX">PIX</option>
           <option value="Aplicação">Aplicação</option>
           <option value="Câmbio">Câmbio</option>
+          <option value="Depósito">Depósito</option>
         </select>
         <button
           disabled={!canSubmit}

--- a/utils/transaction-helper.ts
+++ b/utils/transaction-helper.ts
@@ -1,0 +1,12 @@
+import type { TransactionData } from '@/app/api/transactions/types'
+
+export const transactionHelper = {
+  parseAmount: (value: string) => Number(value.replace(/\D/g, '')) / 100,
+  formatAmount: (value: number) =>
+    new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+    }).format(value),
+  isOutgoing: (type: TransactionData['transaction_type']) =>
+    type === 'PIX' || type === 'Câmbio',
+}


### PR DESCRIPTION
## Summary
- add `Depósito` as a valid transaction type
- update new transaction form with new option
- track balance updates when creating, updating and deleting transactions
- share helper functions for parsing and formatting currency values

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68864b48c180832b8061540ffa0204fd