### PR TITLE
feat: add statement filters

### DIFF
--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -9,9 +9,25 @@ export async function GET(request: NextRequest) {
   const from = (page - 1) * limit
   const to = from + limit - 1
 
-  const { data, error, count } = await supabase
-    .from('transactions')
-    .select('*', { count: 'exact' })
+  const type = url.searchParams.get('type')
+  const period = url.searchParams.get('period')
+
+  let query = supabase.from('transactions').select('*', { count: 'exact' })
+
+  if (type) {
+    query = query.eq('transaction_type', type)
+  }
+
+  if (period) {
+    const days = parseInt(period, 10)
+    if (!Number.isNaN(days)) {
+      const date = new Date()
+      date.setDate(date.getDate() - days)
+      query = query.gte('created_at', date.toISOString())
+    }
+  }
+
+  const { data, error, count } = await query
     .order('created_at', { ascending: false })
     .range(from, to)
 

--- a/app/statement/page.tsx
+++ b/app/statement/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useSWRConfig } from 'swr'
 import { useInView } from 'react-intersection-observer'
@@ -17,6 +17,9 @@ export default function Statement() {
   const router = useRouter()
   const { mutate: mutateHome } = useSWRConfig()
 
+  const [typeFilter, setTypeFilter] = useState('')
+  const [periodFilter, setPeriodFilter] = useState('')
+
   const {
     transactions,
     hasMore,
@@ -24,13 +27,20 @@ export default function Statement() {
     setSize,
     mutate: mutateTransactions,
     isValidating,
-  } = useTransactions()
+  } = useTransactions({
+    type: typeFilter || undefined,
+    period: periodFilter ? Number(periodFilter) : undefined,
+  })
 
   const { ref, inView } = useInView({ rootMargin: '200px' })
 
   useEffect(() => {
     if (inView && hasMore && !isValidating) setSize(size + 1)
   }, [inView, hasMore, isValidating, size, setSize])
+
+  useEffect(() => {
+    setSize(1)
+  }, [typeFilter, periodFilter, setSize])
 
   const handleDelete = async (transaction_id: string) => {
     try {
@@ -53,6 +63,29 @@ export default function Statement() {
   return (
     <div className="flex flex-col gap-4 p-6 bg-white rounded-lg shadow-md">
       <h2 className="font-bold text-2xl">Extrato</h2>
+      <div className="flex flex-col sm:flex-row gap-4">
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          className="py-2 pl-3 bg-white border border-foreground rounded-lg text-foreground appearance-none bg-[url('/static/icons/arrow-down.svg')] bg-no-repeat bg-right focus:outline-none focus:ring-2 focus:ring-tomato focus:border-transparent transition"
+        >
+          <option value="">Todos os tipos</option>
+          <option value="PIX">PIX</option>
+          <option value="Aplicação">Aplicação</option>
+          <option value="Câmbio">Câmbio</option>
+          <option value="Depósito">Depósito</option>
+        </select>
+        <select
+          value={periodFilter}
+          onChange={(e) => setPeriodFilter(e.target.value)}
+          className="py-2 pl-3 bg-white border border-foreground rounded-lg text-foreground appearance-none bg-[url('/static/icons/arrow-down.svg')] bg-no-repeat bg-right focus:outline-none focus:ring-2 focus:ring-tomato focus:border-transparent transition"
+        >
+          <option value="">Todo o período</option>
+          <option value="7">Últimos 7 dias</option>
+          <option value="15">Últimos 15 dias</option>
+          <option value="30">Últimos 30 dias</option>
+        </select>
+      </div>
       <div className="flex flex-col gap-4">
         {transactions.length === 0 ? (
           <p className="text-center text-sm text-battleship-gray">

--- a/utils/useTransactions.ts
+++ b/utils/useTransactions.ts
@@ -3,18 +3,30 @@ import { fetcher } from '@/utils/fetcher'
 import type { GetResponse, TransactionData } from '@/app/api/transactions/types'
 
 export const LIMIT = 5
-const getKey = (pageIndex: number, previousPage: GetResponse | null) => {
-  if (previousPage && !previousPage.hasMore) return null
 
-  const params = new URLSearchParams({
-    limit: LIMIT.toString(),
-    page: (pageIndex + 1).toString(),
-  })
-
-  return `/api/transactions?${params.toString()}`
+interface TransactionsFilters {
+  type?: TransactionData['transaction_type']
+  period?: number
 }
 
-export function useTransactions() {
+export function useTransactions(filters: TransactionsFilters = {}) {
+  const getKey = (
+    pageIndex: number,
+    previousPage: GetResponse | null,
+  ): string | null => {
+    if (previousPage && !previousPage.hasMore) return null
+
+    const params = new URLSearchParams({
+      limit: LIMIT.toString(),
+      page: (pageIndex + 1).toString(),
+    })
+
+    if (filters.type) params.set('type', filters.type)
+    if (filters.period) params.set('period', filters.period.toString())
+
+    return `/api/transactions?${params.toString()}`
+  }
+
   const { data, error, size, setSize, mutate, isValidating } =
     useSWRInfinite<GetResponse>(getKey, fetcher, {
       revalidateFirstPage: false,


### PR DESCRIPTION
## Summary
- add transaction type and period filters on statement page
- support filters in API and useTransactions hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689298446090832bb6e3d8b2a5ae2fbb