### PR TITLE
Add Zustand store for transaction filters

### DIFF
--- a/modules/transactions/components/Statement.tsx
+++ b/modules/transactions/components/Statement.tsx
@@ -14,7 +14,8 @@ import Delete from '@/public/static/icons/delete.svg'
 import { Loader } from '@/components/Loader'
 import { formatBRDateFromISO } from '@/utils/date'
 import { useTransactionKinds } from '@/modules/transactions/hooks/useTransactionKinds'
-import { type TransactionsFilters } from '@/app/api/transactions/types'
+import { useTransactionsFiltersStore } from '@/modules/transactions/stores/useTransactionsFiltersStore'
+import { shallow } from 'zustand/shallow'
 import { SWR_KEYS } from '@/utils/swr-keys'
 
 export function Statement() {
@@ -25,15 +26,21 @@ export function Statement() {
   const { mutate: mutateHome } = useSWRConfig()
   const { ref, inView } = useInView({ rootMargin: '200px' })
 
-  const [period, setPeriod] = useState<'' | '7' | '15' | '30'>('')
-  const [transactionTypeFilter, setTransactionTypeFilter] = useState<string>('')
-
-  const filters: TransactionsFilters = useMemo(
-    () => ({
-      period: period ? (Number(period) as 7 | 15 | 30) : undefined,
-      transactionType: transactionTypeFilter || undefined,
+  const {
+    period,
+    transactionTypeFilter,
+    setPeriod,
+    setTransactionTypeFilter,
+    filters,
+  } = useTransactionsFiltersStore(
+    (state) => ({
+      period: state.period,
+      transactionTypeFilter: state.transactionType,
+      setPeriod: state.setPeriod,
+      setTransactionTypeFilter: state.setTransactionType,
+      filters: state.filters,
     }),
-    [period, transactionTypeFilter],
+    shallow,
   )
 
   const {

--- a/modules/transactions/index.ts
+++ b/modules/transactions/index.ts
@@ -1,2 +1,3 @@
 export * from './components'
 export * from './hooks'
+export * from './stores'

--- a/modules/transactions/stores/index.ts
+++ b/modules/transactions/stores/index.ts
@@ -1,0 +1,1 @@
+export * from './useTransactionsFiltersStore'

--- a/modules/transactions/stores/useTransactionsFiltersStore.ts
+++ b/modules/transactions/stores/useTransactionsFiltersStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand'
+import { type TransactionsFilters } from '@/app/api/transactions/types'
+
+type PeriodOption = '' | '7' | '15' | '30'
+
+type TransactionsFiltersState = {
+  period: PeriodOption
+  transactionType: string
+  filters: TransactionsFilters
+}
+
+type TransactionsFiltersActions = {
+  setPeriod: (period: PeriodOption) => void
+  setTransactionType: (transactionType: string) => void
+  reset: () => void
+}
+
+const buildFilters = (
+  period: PeriodOption,
+  transactionType: string,
+): TransactionsFilters => ({
+  ...(period ? { period: Number(period) as 7 | 15 | 30 } : {}),
+  ...(transactionType ? { transactionType } : {}),
+})
+
+const INITIAL_PERIOD: PeriodOption = ''
+const INITIAL_TRANSACTION_TYPE = ''
+
+export const useTransactionsFiltersStore = create<
+  TransactionsFiltersState & TransactionsFiltersActions
+>((set) => ({
+  period: INITIAL_PERIOD,
+  transactionType: INITIAL_TRANSACTION_TYPE,
+  filters: {},
+  setPeriod: (period) =>
+    set((state) => ({
+      period,
+      filters: buildFilters(period, state.transactionType),
+    })),
+  setTransactionType: (transactionType) =>
+    set((state) => ({
+      transactionType,
+      filters: buildFilters(state.period, transactionType),
+    })),
+  reset: () =>
+    set(() => ({
+      period: INITIAL_PERIOD,
+      transactionType: INITIAL_TRANSACTION_TYPE,
+      filters: {},
+    })),
+}))

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-intersection-observer": "^9.16.0",
         "react-toastify": "^11.0.5",
         "recharts": "^3.1.2",
-        "swr": "^2.3.3"
+        "swr": "^2.3.3",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -7319,6 +7320,35 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-intersection-observer": "^9.16.0",
     "react-toastify": "^11.0.5",
     "recharts": "^3.1.2",
-    "swr": "^2.3.3"
+    "swr": "^2.3.3",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add Zustand dependency and a centralized store for transaction filters
- refactor the Statement component to consume the shared filters store
- re-export stores from the transactions module for easier imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68def98eafb8832b959c010c7f885e31