### PR TITLE
Fix Statement filters store typing for Zustand selector

### DIFF
--- a/modules/transactions/components/Statement.tsx
+++ b/modules/transactions/components/Statement.tsx
@@ -14,9 +14,20 @@ import Delete from '@/public/static/icons/delete.svg'
 import { Loader } from '@/components/Loader'
 import { formatBRDateFromISO } from '@/utils/date'
 import { useTransactionKinds } from '@/modules/transactions/hooks/useTransactionKinds'
-import { useTransactionsFiltersStore } from '@/modules/transactions/stores/useTransactionsFiltersStore'
+import {
+  useTransactionsFiltersStore,
+  type TransactionsFiltersStore,
+} from '@/modules/transactions/stores/useTransactionsFiltersStore'
 import { shallow } from 'zustand/shallow'
 import { SWR_KEYS } from '@/utils/swr-keys'
+
+const selectTransactionsFilters = (state: TransactionsFiltersStore) => ({
+  period: state.period,
+  transactionTypeFilter: state.transactionType,
+  setPeriod: state.setPeriod,
+  setTransactionTypeFilter: state.setTransactionType,
+  filters: state.filters,
+})
 
 export function Statement() {
   const router = useRouter()
@@ -26,22 +37,8 @@ export function Statement() {
   const { mutate: mutateHome } = useSWRConfig()
   const { ref, inView } = useInView({ rootMargin: '200px' })
 
-  const {
-    period,
-    transactionTypeFilter,
-    setPeriod,
-    setTransactionTypeFilter,
-    filters,
-  } = useTransactionsFiltersStore(
-    (state) => ({
-      period: state.period,
-      transactionTypeFilter: state.transactionType,
-      setPeriod: state.setPeriod,
-      setTransactionTypeFilter: state.setTransactionType,
-      filters: state.filters,
-    }),
-    shallow,
-  )
+  const { period, transactionTypeFilter, setPeriod, setTransactionTypeFilter, filters } =
+    useTransactionsFiltersStore(selectTransactionsFilters, shallow)
 
   const {
     transactions,

--- a/modules/transactions/stores/useTransactionsFiltersStore.ts
+++ b/modules/transactions/stores/useTransactionsFiltersStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { type TransactionsFilters } from '@/app/api/transactions/types'
 
-type PeriodOption = '' | '7' | '15' | '30'
+export type PeriodOption = '' | '7' | '15' | '30'
 
 type TransactionsFiltersState = {
   period: PeriodOption
@@ -26,9 +26,10 @@ const buildFilters = (
 const INITIAL_PERIOD: PeriodOption = ''
 const INITIAL_TRANSACTION_TYPE = ''
 
-export const useTransactionsFiltersStore = create<
+export type TransactionsFiltersStore =
   TransactionsFiltersState & TransactionsFiltersActions
->((set) => ({
+
+export const useTransactionsFiltersStore = create<TransactionsFiltersStore>((set) => ({
   period: INITIAL_PERIOD,
   transactionType: INITIAL_TRANSACTION_TYPE,
   filters: {},

--- a/modules/transactions/stores/useTransactionsFiltersStore.ts
+++ b/modules/transactions/stores/useTransactionsFiltersStore.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { createWithEqualityFn } from 'zustand/traditional'
 import { type TransactionsFilters } from '@/app/api/transactions/types'
 
 export type PeriodOption = '' | '7' | '15' | '30'
@@ -29,7 +29,7 @@ const INITIAL_TRANSACTION_TYPE = ''
 export type TransactionsFiltersStore =
   TransactionsFiltersState & TransactionsFiltersActions
 
-export const useTransactionsFiltersStore = create<TransactionsFiltersStore>((set) => ({
+export const useTransactionsFiltersStore = createWithEqualityFn<TransactionsFiltersStore>((set) => ({
   period: INITIAL_PERIOD,
   transactionType: INITIAL_TRANSACTION_TYPE,
   filters: {},


### PR DESCRIPTION
## Summary
- export the transactions filters store types so components can share the state shape
- apply a typed selector in the Statement component when reading the filters store to resolve the TypeScript error

## Testing
- npm run build *(fails: unable to download the Inter font from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68defcf7cbdc832bbbe05fea2d2e4fa6